### PR TITLE
MTB-161: replacing crypto:rand_bytes deprecated method call

### DIFF
--- a/src/oauth.erl
+++ b/src/oauth.erl
@@ -78,7 +78,7 @@ signature_params(Consumer, Params, Token) ->
 signature_params(Consumer, Params) ->
   Timestamp = unix_timestamp(),
   % limit Nonce to 0-9A-F, base64 characters like = can be troublesome
-  <<N:256>> = crypto:rand_bytes(32),
+  <<N:256>> = crypto:strong_rand_bytes(32),
   Nonce = lists:flatten(io_lib:format ("~.16B",[N])),
   [ {"oauth_version", "1.0"}
   , {"oauth_nonce", Nonce}


### PR DESCRIPTION
replacing crypto:rand_bytes deprecated method call with strong_rand_bytes